### PR TITLE
Fix translate SSR namespaces

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -29,9 +29,7 @@ export default async function handleRequest(
     ],
   });
 
-  const namespaces = extractNamespaces(
-    context.routeModules as EntryContext['routeModules'],
-  );
+  const namespaces = extractNamespaces(remixContext.routeModules);
 
   await initI18nServer(
     context.storefront.i18n.language.toLowerCase(),

--- a/app/i18n/extractNamespaces.ts
+++ b/app/i18n/extractNamespaces.ts
@@ -1,6 +1,7 @@
 import {type UNSAFE_RouteModules} from '@remix-run/react';
 import {type EntryContext} from '@remix-run/server-runtime';
 
+//https://github.com/sergiodxa/remix-i18next/blob/main/src/client.ts
 export function extractNamespaces(
   routeModules: UNSAFE_RouteModules | EntryContext['routeModules'],
 ): string[] {


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Refactored `extractNamespaces` function call in `entry.server.tsx` to use `remixContext.routeModules` for better context handling.
- Added a reference comment for `remix-i18next` in the `extractNamespaces` function to provide context and documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entry.server.tsx</strong><dd><code>Refactor `extractNamespaces` usage in `entry.server.tsx`</code>&nbsp; </dd></summary>
<hr>

app/entry.server.tsx
<li>Refactored <code>extractNamespaces</code> function call to use <br><code>remixContext.routeModules</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-store/pull/113/files#diff-dcc994af97e802c6310510c47d7f6b6253b153032fbe29a65b133c88238a77c6">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extractNamespaces.ts</strong><dd><code>Add reference comment for `remix-i18next` in `extractNamespaces`</code></dd></summary>
<hr>

app/i18n/extractNamespaces.ts
<li>Added a reference comment for <code>remix-i18next</code> in <code>extractNamespaces</code> <br>function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-store/pull/113/files#diff-d16cfa31fb90a3be25660c057139a1df5f139f6d4fd81b87f8b1cc8b298fa72b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

